### PR TITLE
Fixing apt-get install python-pip - 404  Not Found on Ubuntu 14.04

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Update apt cache if not done today
+  apt: update_cache=yes cache_valid_time=86400
+
 - name: Install common apt packages
   apt: pkg={{ item }} state=latest
   with_items: common_packages

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -6,7 +6,7 @@
   sudo: yes
 
 - name: Install logstash apt packages
-  apt: pkg={{ item }} update_cache=yes state=present
+  apt: pkg={{ item }} state=latest
   with_items:
    - logstash
    - logstash-contrib


### PR DESCRIPTION
Fixes #4 
